### PR TITLE
Fix submit button width for tablet and up.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -462,6 +462,7 @@ margin-right: 5px;
 	border-radius: 3px;
 	-webkit-border-radius: 3px;
 	-moz-border-radius: 3px;
+	width: 100%;
 	display: inline-block;
 	margin-left: .2em;
 }
@@ -683,7 +684,6 @@ margin-right: 14px;
 	color: #fff;
 	background-color: #6CD286;
 	padding: .7em 2em;
-	width: 100%;
 	border-radius: 3px;
 	-webkit-border-radius: 3px;
 	-moz-border-radius: 3px;


### PR DESCRIPTION
Minor fix for the submit button on tablet and up. It was inheriting `width: 82%` from mobile, causing the sizing to be off in tablet, so I moved `width: 100%` from the desktop media query into tablet.